### PR TITLE
Bugfix/fix regres (#32)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -47,3 +47,7 @@ Kinetic Platform [handlers] (2021-07-01)
 Kinetic Platform [bridge-adapter] (2021-09-08)
   * [kinetic-bridgehub-adapter-kinetic-platform]
     * Fixed ampersands in parameters issue KP-3631.
+
+Kinetic Platform [handlers] (2021-10-14)
+  * [kinetic_request_ce_notification_template_send_v3]
+    * fixed regression caused in previous update.  

--- a/handlers/kinetic_request_ce_notification_template_send_v3/changelog.md
+++ b/handlers/kinetic_request_ce_notification_template_send_v3/changelog.md
@@ -12,4 +12,7 @@
  - updated the regex for image cid.  The previous regex was greedy and took too much.
 
 2021-07-01
- - added support for modern url to fetch attachments
+ - added support for modern url to fetch attachments.
+
+2021-10-14
+ - fixed regression that was caused in previous commit.

--- a/handlers/kinetic_request_ce_notification_template_send_v3/handler/init.rb
+++ b/handlers/kinetic_request_ce_notification_template_send_v3/handler/init.rb
@@ -460,7 +460,7 @@ class KineticRequestCeNotificationTemplateSendV3
         embedded_images = {}
 
         # Iterate over the body and embed necessary images
-        htmlbody.scan(/"cid:(.*)"/) do |match|
+        htmlbody.scan(/"cid:(.*?)"/) do |match|
           # The match variable is an array of Regex groups (specified with
           # parentheses); in this case the first match is the url
           url = match.first


### PR DESCRIPTION
* PER-234 fixed regression in handler
There was a regression introduced in PER-220 to the notification template send v3 handler.

* PER-234 updated change log