### PR TITLE
Bugfix/kapp tables

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -77,3 +77,6 @@ Kinetic Platform [bridge-adapter] (2022-12-23)
   * [kinetic-bridgehub-adapter-kinetic-platform]
    * KP-5895 added webApi search/retrieve functionality (space and kapp)
 
+Kinetic Platform [handlers] (2023-09-06)
+  * [kinetic_request_ce_submission_db_insert_v1]
+   * bug fixes to create kapp table if it doesn't exist

--- a/changelog.md
+++ b/changelog.md
@@ -80,3 +80,7 @@ Kinetic Platform [bridge-adapter] (2022-12-23)
 Kinetic Platform [handlers] (2023-09-06)
   * [kinetic_request_ce_submission_db_insert_v1]
    * bug fixes to create kapp table if it doesn't exist
+
+Kinetic Platform [handlers] (2023-09-11)
+  * [kinetic_request_ce_submission_db_insert_v1]
+   * bug fixes to prevent kapp table creation when datastore

--- a/handlers/kinetic_request_ce_submission_db_insert_v1/CHANGELOG.md
+++ b/handlers/kinetic_request_ce_submission_db_insert_v1/CHANGELOG.md
@@ -23,3 +23,6 @@ Kinetic Request CE Submission DB Insert V1.5 (2022-08-15)
 
 Kinetic Request CE Submission DB Insert (2023-09-06)
 * bug fixes to create kapp table if it doesn't exist
+
+Kinetic Request CE Submission DB Insert (2023-09-11)
+* bug fixes to prevent kapp table creation when datastore

--- a/handlers/kinetic_request_ce_submission_db_insert_v1/CHANGELOG.md
+++ b/handlers/kinetic_request_ce_submission_db_insert_v1/CHANGELOG.md
@@ -20,3 +20,6 @@ Kinetic Request CE Submission DB Insert V1.4 (2022-07-03)
 
 Kinetic Request CE Submission DB Insert V1.5 (2022-08-15)
 * KD8W-104 added enable debug logging info value. Updated the SQL logger to log to engine logs. Removed submission value logging.
+
+Kinetic Request CE Submission DB Insert (2023-09-06)
+* bug fixes to create kapp table if it doesn't exist

--- a/handlers/kinetic_request_ce_submission_db_insert_v1/handler/init.rb
+++ b/handlers/kinetic_request_ce_submission_db_insert_v1/handler/init.rb
@@ -436,9 +436,11 @@ class KineticRequestCeSubmissionDbInsertV1
         end
 
         # Add columns if the kapp table does not have all kapp fields defined
-        update_kapp_table_columns({
-          :kapp_slug => kapp_slug
-        })
+        if datastore != "yes" then
+          update_kapp_table_columns({
+            :kapp_slug => kapp_slug
+          })
+        end
 
         # Get table names
         form_table_name     = get_form_table_name(kapp_slug, form_slug)

--- a/handlers/kinetic_request_ce_submission_db_insert_v1/handler/init.rb
+++ b/handlers/kinetic_request_ce_submission_db_insert_v1/handler/init.rb
@@ -968,6 +968,12 @@ class KineticRequestCeSubmissionDbInsertV1
 ##########################################################################################################
 
   def update_kapp_table_columns(args)
+    # Create Kapp Table if it doesn't exist        
+    if @db.table_exists?(args[:kapp_slug].to_sym) == false
+      puts "Kapp #{args[:kapp_slug]} not found " if @enable_debug_logging
+      generate_kapp_table(args[:kapp_slug])
+    end
+
     # Get list of columns for the kapp table
     table_columns = get_table_column_names(args[:kapp_slug].to_sym)
 


### PR DESCRIPTION
The kapp tables were being created even if the datastore submission parameter was set to yes. When it is a datastore submission, a datastore kapp table should not be created.